### PR TITLE
Code template - Transaction and PerformanceMonitor

### DIFF
--- a/src/main/java/org/idea/plugin/atg/template/live/LiveTemplateProvider.java
+++ b/src/main/java/org/idea/plugin/atg/template/live/LiveTemplateProvider.java
@@ -1,0 +1,18 @@
+package org.idea.plugin.atg.template.live;
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider;
+import org.jetbrains.annotations.Nullable;
+
+public class LiveTemplateProvider implements DefaultLiveTemplatesProvider {
+
+    @Override
+    public String[] getDefaultLiveTemplateFiles() {
+        return new String[]{"liveTemplates/ATG"};
+    }
+
+    @Nullable
+    @Override
+    public String[] getHiddenLiveTemplateFiles() {
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -148,6 +148,7 @@
         <framework.detector implementation="org.idea.plugin.atg.framework.AtgFrameworkDetector"/>
         <iconProvider implementation="org.idea.plugin.atg.module.AtgIconProvider" id="atgFolders" order="first"/>
 
+        <defaultLiveTemplatesProvider implementation="org.idea.plugin.atg.template.live.LiveTemplateProvider"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/liveTemplates/ATG.xml
+++ b/src/main/resources/liveTemplates/ATG.xml
@@ -1,0 +1,15 @@
+<templateSet group="ATG">
+    <template name="trytd" value="try (AutoCloseTransactionDemarcation td =&#10;             new AutoCloseTransactionDemarcation($SELECTION$$TRANSACTION_MANAGER$$END$, TransactionDemarcation.REQUIRED)) {&#10;    // TODO: your code goes here&#10;    td.setSuccess(true);&#10;} catch (TransactionDemarcationException e) {&#10;    throw e;&#10;}" description="Auto-closed transaction template" toReformat="true" toShortenFQNames="true">
+        <variable name="TRANSACTION_MANAGER" expression="" defaultValue="&quot;transactionManager&quot;" alwaysStopAt="true" />
+        <context>
+            <option name="JAVA_CODE" value="true" />
+        </context>
+    </template>
+    <template name="trypm" value="// TODO: Move to constants block (consider using shortcut CTRL+ALT+C)&#10;final String perfMonitorName = &quot;$CURRENT_CLASS_NAME$&quot;;&#10;final String perfMonitorParam = &quot;$CURRENT_METHOD_NAME$&quot;;&#10;try {&#10;    PerformanceMonitor.startOperation(perfMonitorName, perfMonitorParam);&#10;    // TODO: Your code goes here&#10;} finally {&#10;    PerformanceMonitor.endOperation(perfMonitorName, perfMonitorParam);&#10;}&#10;        " description="Perfomance monitor transaction template" toReformat="true" toShortenFQNames="true">
+        <variable name="CURRENT_CLASS_NAME" expression="className()" defaultValue="" alwaysStopAt="true" />
+        <variable name="CURRENT_METHOD_NAME" expression="methodName()" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="JAVA_CODE" value="true" />
+        </context>
+    </template>
+</templateSet>

--- a/src/main/resources/liveTemplates/ATG.xml
+++ b/src/main/resources/liveTemplates/ATG.xml
@@ -1,11 +1,11 @@
 <templateSet group="ATG">
-    <template name="trytd" value="try (AutoCloseTransactionDemarcation td =&#10;             new AutoCloseTransactionDemarcation($SELECTION$$TRANSACTION_MANAGER$$END$, TransactionDemarcation.REQUIRED)) {&#10;    // TODO: your code goes here&#10;    td.setSuccess(true);&#10;} catch (TransactionDemarcationException e) {&#10;    throw e;&#10;}" description="Auto-closed transaction template" toReformat="true" toShortenFQNames="true">
+    <template name="trytd" value="try (atg.dtm.AutoCloseTransactionDemarcation td =&#10;             new AutoCloseTransactionDemarcation($SELECTION$$TRANSACTION_MANAGER$$END$, atg.dtm.TransactionDemarcation.REQUIRED)) {&#10;    // TODO: your code goes here&#10;    td.setSuccess(true);&#10;} catch (atg.dtm.TransactionDemarcationException e) {&#10;    throw e;&#10;}" description="Auto-closed transaction template" toReformat="true" toShortenFQNames="true">
         <variable name="TRANSACTION_MANAGER" expression="" defaultValue="&quot;transactionManager&quot;" alwaysStopAt="true" />
         <context>
             <option name="JAVA_CODE" value="true" />
         </context>
     </template>
-    <template name="trypm" value="// TODO: Move to constants block (consider using shortcut CTRL+ALT+C)&#10;final String perfMonitorName = &quot;$CURRENT_CLASS_NAME$&quot;;&#10;final String perfMonitorParam = &quot;$CURRENT_METHOD_NAME$&quot;;&#10;try {&#10;    PerformanceMonitor.startOperation(perfMonitorName, perfMonitorParam);&#10;    // TODO: Your code goes here&#10;} finally {&#10;    PerformanceMonitor.endOperation(perfMonitorName, perfMonitorParam);&#10;}&#10;        " description="Perfomance monitor transaction template" toReformat="true" toShortenFQNames="true">
+    <template name="trypm" value="// TODO: Move to constants block (consider using shortcut CTRL+ALT+C)&#10;final String monitoredClass = &quot;$CURRENT_CLASS_NAME$&quot;;&#10;final String monitoredMethod = &quot;$CURRENT_METHOD_NAME$&quot;;&#10;try {&#10;    atg.service.perfmonitor.PerformanceMonitor.startOperation(monitoredClass, monitoredMethod);&#10;    // TODO: Your code goes here&#10;} finally {&#10;    atg.service.perfmonitor.PerformanceMonitor.endOperation(monitoredClass, monitoredMethod);&#10;}&#10;        " description="Perfomance monitor transaction template" toReformat="true" toShortenFQNames="true">
         <variable name="CURRENT_CLASS_NAME" expression="className()" defaultValue="" alwaysStopAt="true" />
         <variable name="CURRENT_METHOD_NAME" expression="methodName()" defaultValue="" alwaysStopAt="true" />
         <context>


### PR DESCRIPTION
Added live templates for auto-closable transactions and performance monitor. 
You can type 'trytd' or 'trypm' for quick access to try-with-resources block.
For trytd should defined transactionManager in your class.