### PR TITLE
LCT-1643: Changed autocomplete for missing fields in the property file.

### DIFF
--- a/src/main/java/org/idea/plugin/atg/completion/AtgPropertyLookupElement.java
+++ b/src/main/java/org/idea/plugin/atg/completion/AtgPropertyLookupElement.java
@@ -12,7 +12,7 @@ public class AtgPropertyLookupElement extends LookupElement {
 
     public AtgPropertyLookupElement(@NotNull final PsiMethod setterMethod) {
         this.psiMethod = setterMethod;
-        this.lookupString = AtgComponentUtil.convertSetterToVariableName(psiMethod) + "=";
+        this.lookupString = AtgComponentUtil.convertSetterToVariableName(psiMethod);
     }
 
     public AtgPropertyLookupElement(@NotNull final PsiMethod setterMethod, @NotNull final String lookupString) {

--- a/src/main/java/org/idea/plugin/atg/editorActions/AtgCompletionPropertyAutoPopupHandler.java
+++ b/src/main/java/org/idea/plugin/atg/editorActions/AtgCompletionPropertyAutoPopupHandler.java
@@ -1,0 +1,23 @@
+package org.idea.plugin.atg.editorActions;
+
+import com.intellij.codeInsight.AutoPopupController;
+import com.intellij.codeInsight.editorActions.CompletionAutoPopupHandler;
+import com.intellij.lang.properties.psi.impl.PropertiesFileImpl;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+public class AtgCompletionPropertyAutoPopupHandler extends CompletionAutoPopupHandler {
+
+    @NotNull
+    @Override
+    public Result checkAutoPopup(char charTyped, Project project, Editor editor, PsiFile file) {
+        Result result = Result.CONTINUE;
+        if (file instanceof PropertiesFileImpl && charTyped == '=') {
+            AutoPopupController.getInstance(project).scheduleAutoPopup(editor);
+            result = Result.STOP;
+        }
+        return result;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -148,6 +148,8 @@
         <framework.detector implementation="org.idea.plugin.atg.framework.AtgFrameworkDetector"/>
         <iconProvider implementation="org.idea.plugin.atg.module.AtgIconProvider" id="atgFolders" order="first"/>
 
+        <typedHandler implementation="org.idea.plugin.atg.editorActions.AtgCompletionPropertyAutoPopupHandler" id="atgCompletionAutoPopup"
+                      order="first"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Added autocompletion after entering the '=' character in properties file

When editing a component properties file give hints when creating injections

Example: in class ru.some.Test there is a field testTools
There is a component /ru/some/TestTools.properties
When you edit the ru.some.Test.properties and enter the string testTools= give a tooltip /ru/some/testTools
Also when you click the '=' sign